### PR TITLE
fixed operator warnings on both/either target

### DIFF
--- a/src/BBase.cpp
+++ b/src/BBase.cpp
@@ -84,3 +84,18 @@ TUint32 Milliseconds() {
   return (TUint32)(esp_timer_get_time() / 1000);
 #endif
 }
+
+#ifndef __XTENSA__
+void *operator new(size_t size) { return AllocMem(size, MEMF_SLOW); }
+void *operator new[](size_t size) { return AllocMem(size, MEMF_SLOW); }
+
+void operator delete(void *ptr) {
+  //
+  FreeMem(ptr);
+}
+
+void operator delete[](void *ptr) {
+  //
+  FreeMem(ptr);
+}
+#endif

--- a/src/BBase.h
+++ b/src/BBase.h
@@ -23,6 +23,7 @@ public:
 
 extern TAny *AllocMem(size_t size, TInt32 flags);
 extern void FreeMem(TAny *ptr);
+#ifdef __XTENSA__
 inline void *operator new(size_t size) { return AllocMem(size, MEMF_SLOW); }
 
 inline void *operator new[](size_t size) { return AllocMem(size, MEMF_SLOW); }
@@ -36,6 +37,13 @@ inline void operator delete[](void *ptr) {
   //
   FreeMem(ptr);
 }
+#else
+extern void *operator new(size_t size);
+extern void *operator new[](size_t size);
+
+extern void operator delete(void *ptr);
+extern void operator delete[](void *ptr);
+#endif
 
 extern TUint32 Milliseconds();
 


### PR DESCRIPTION
#15 Operator new/delete warnings.

Added ifdef/ifndef and did the right thing(tm) on both platforms.

Tested SDL/Mac version, and it runs.

No warnings doing make for Go in genus.