### PR TITLE
Clean up includes

### DIFF
--- a/src/BBase.cpp
+++ b/src/BBase.cpp
@@ -1,4 +1,4 @@
-#include "GameEngine.h"
+#include "BBase.h"
 
 #ifndef __XTENSA__
 

--- a/src/BBitmap.cpp
+++ b/src/BBitmap.cpp
@@ -1,4 +1,4 @@
-#include "GameEngine.h"
+#include "BBitmap.h"
 #include <string.h>
 #include "Panic.h"
 

--- a/src/BGameEngine.cpp
+++ b/src/BGameEngine.cpp
@@ -1,7 +1,3 @@
-//
-// Created by Michael Schwartz on 9/5/18.
-//
-
 #include "BGameEngine.h"
 #include "Display.h"
 #include "Controls.h"

--- a/src/BList.h
+++ b/src/BList.h
@@ -2,7 +2,6 @@
 #define BLIST_H
 
 #include "BBase.h"
-#include "BList.h"
 
 /**
  * Two basic types of doubly linked lists:

--- a/src/BResourceManager.cpp
+++ b/src/BResourceManager.cpp
@@ -1,4 +1,5 @@
-#include "GameEngine.h"
+#include "BResourceManager.h"
+#include "BBitmap.h"
 
 // TODO: should application incbin the resources binary?
 

--- a/src/BResourceManager.h
+++ b/src/BResourceManager.h
@@ -11,7 +11,7 @@
  * COMPONENT_EMBED_FILES define in the component.mk for the game.
  */
 #include "BBase.h"
-#include "BBitmap.h"
+class BBitmap;
 
 // Each resource that is loaded requires allocated RAM, so we don't want to just load them all
 // from the FLASH/ROM/RODATA all at once.

--- a/src/BSoundPlayer.cpp
+++ b/src/BSoundPlayer.cpp
@@ -1,5 +1,1 @@
-//
-// Created by Michael Schwartz on 9/13/18.
-//
-
 #include "BSoundPlayer.h"

--- a/src/BSprite.cpp
+++ b/src/BSprite.cpp
@@ -1,4 +1,5 @@
 #include "BSprite.h"
+#include "BViewPort.h"
 #include "BResourceManager.h"
 #include "Display.h"
 

--- a/src/BSprite.h
+++ b/src/BSprite.h
@@ -50,9 +50,8 @@
  * animation engine.
  *
  */
-#include "BBase.h"
+
 #include "BList.h"
-#include "BTypes.h"
 
 class BViewPort;
 class BBitmap;

--- a/src/BTypes.cpp
+++ b/src/BTypes.cpp
@@ -1,4 +1,4 @@
-#include "GameEngine.h"
+#include "BTypes.h"
 
 TBool TRect::Overlaps(TRect &aOther) {
   if (x1 > aOther.x2 || x2 < aOther.x1) {

--- a/src/BViewPort.h
+++ b/src/BViewPort.h
@@ -1,7 +1,7 @@
 #ifndef BVIEWPORT_H
 #define BVIEWPORT_H
 
-#include "GameEngine.h"
+#include "BBase.h"
 
 /**
  * BViewPort encapsulates the view port or displayable area of the world on screen.  For games that

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -1,4 +1,4 @@
-#include "GameEngine.h"
+#include "Display.h"
 
 Display display;
 

--- a/src/Display.h
+++ b/src/Display.h
@@ -7,7 +7,15 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
-#include "GameEngine.h"
+#include "BBitmap.h"
+
+// screen attributes
+#define SCREEN_WIDTH 320
+#define SCREEN_HEIGHT 240
+#define SCREEN_DEPTH 8
+
+#define DISPLAY_WIDTH (SCREEN_WIDTH)
+#define DISPLAY_HEIGHT (SCREEN_HEIGHT)
 
 class Display {
 public:

--- a/src/GameEngine.h
+++ b/src/GameEngine.h
@@ -1,14 +1,6 @@
 #ifndef GAMEENGINE_H
 #define GAMEENGINE_H
 
-// screen attributes
-#define SCREEN_WIDTH 320
-#define SCREEN_HEIGHT 240
-#define SCREEN_DEPTH 8
-
-#define DISPLAY_WIDTH (SCREEN_WIDTH)
-#define DISPLAY_HEIGHT (SCREEN_HEIGHT)
-
 #include "BTypes.h"
 //
 #include "BBase.h"

--- a/src/Panic.cpp
+++ b/src/Panic.cpp
@@ -1,4 +1,4 @@
-#include "GameEngine.h"
+#include "Panic.h"
 
 #ifndef __XTENSA__
 #include <stdlib.h>


### PR DESCRIPTION
#33
Eliminated most uses of GameEngine.h WITHIN creative-engine only - it is still useful for game code.

In Genus, for example, we'll want to include GameEngine.h instead of adding several includes.  Using GameEngine.h makes ALL of creative-engine available at our fingertips all the time.