### PR TITLE
Improve controller support

### DIFF
--- a/src/Controls.h
+++ b/src/Controls.h
@@ -54,9 +54,12 @@ public:
     return (cKeys & bits) ? ETrue : EFalse;
   }
 
+  void Rumble(TFloat aStrength, TInt aTime);
+
 public:
   TUint16 bKeys, cKeys, dKeys;
 #ifdef CONTROLLER_SUPPORT
+  SDL_Haptic         *haptic;
   SDL_GameController *ctrl;
 #endif
 };


### PR DESCRIPTION
Existing implementation was broken for PS4 as it was initially written for XBOX360's controller.
The issue was that the "button up" events weren't processed resulting in the effect of "stuck" keys.

Adds support for controller rumble.