### PR TITLE
13 object layer

### DIFF
--- a/src/BBitmap.cpp
+++ b/src/BBitmap.cpp
@@ -106,8 +106,12 @@ void BBitmap::Remap(TUint16 aStartColor, TUint16 aNumColors) {
   }
   for (TInt color=0; color < aNumColors; color++) {
     mPalette[color+aStartColor] = mPalette[color];
+    auto rgb = mPalette[color+aStartColor];
+    if (rgb.r == 0xff && rgb.g == 0 && rgb.b == 0xff) {
+      mTransparentColor = color+aStartColor;
+   }
   }
-  mTransparentColor += aStartColor;
+//  mTransparentColor += aStartColor;
 }
 
 void BBitmap::SetPalette(TRGB aPalette[], TInt aIndex, TInt aCount) {

--- a/src/BMapPlayfield.cpp
+++ b/src/BMapPlayfield.cpp
@@ -7,6 +7,9 @@ BMapPlayfield::BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId) : BPlayf
   mMapHeight = mTileMap->mHeight;
   mMapData = &mTileMap->mMapData[0];
   mTileset = mTileMap->mTiles;
+  mObjectProgram = mTileMap->mObjectProgram;
+  mObjectCount= mTileMap->mObjectCount;
+  printf("BMapPlayfield: %d Objects\n", mObjectCount);
 }
 
 BMapPlayfield::~BMapPlayfield() {

--- a/src/BMapPlayfield.h
+++ b/src/BMapPlayfield.h
@@ -31,6 +31,9 @@ public:
   // cell is tile number | (attribute << 16)
   TUint32 GetCell(TFloat aWorldX, TFloat aWorldY);
 
+  TUint16 mObjectCount;
+  TUint16 *mObjectProgram;
+
 protected:
   BViewPort *mViewPort;
   BTileMap *mTileMap;

--- a/src/BTileMap.cpp
+++ b/src/BTileMap.cpp
@@ -2,11 +2,17 @@
 
 BTileMap::BTileMap(void *aRomData) {
   TUint16 *rom = (TUint16 *)aRomData;
+  WordDump(rom, 50);
   mTiles = gResourceManager.LoadBitmap(rom[0]);
-  mWidth = rom[1]; // romTileMap->mWidth;
-  mHeight = rom[2]; // romTileMap->mHeight;
+  mObjectCount = rom[1];
+  mObjectProgram= &rom[2];
+  TInt programEnd = 3 + mObjectCount+3+2;
+  mWidth = rom[programEnd]; // romTileMap->mWidth;
+  mHeight = rom[programEnd+1]; // romTileMap->mHeight;
   mMapData = new TUint32[mWidth * mHeight];
-  memcpy(mMapData, &rom[3], mWidth * mHeight * sizeof(TUint32));
+  memcpy(mMapData, &rom[programEnd+2], mWidth * mHeight * sizeof(TUint32));
+  printf("TILEMAP is %d by %d\n", mWidth, mHeight);
+  LongDump(mMapData, 32);
 }
 
 BTileMap::~BTileMap() {
@@ -17,7 +23,7 @@ BTileMap::~BTileMap() {
 
 TUint8 *BTileMap::TilePtr(TInt aRow, TInt aCol) {
   const TInt index = aRow * mWidth + aCol,
-  tileNumber = mMapData[index] & 0xffff;
+  tileNumber = mMapData[index] & TUint32(0xffff);
 
   const TInt tw = mTiles->Width() / TILESIZE,
     row = tileNumber / tw,

--- a/src/BTileMap.cpp
+++ b/src/BTileMap.cpp
@@ -2,7 +2,6 @@
 
 BTileMap::BTileMap(void *aRomData) {
   TUint16 *rom = (TUint16 *)aRomData;
-  WordDump(rom, 50);
   mTiles = gResourceManager.LoadBitmap(rom[0]);
   mObjectCount = rom[1];
   mObjectProgram= &rom[2];
@@ -12,7 +11,6 @@ BTileMap::BTileMap(void *aRomData) {
   mMapData = new TUint32[mWidth * mHeight];
   memcpy(mMapData, &rom[programEnd+2], mWidth * mHeight * sizeof(TUint32));
   printf("TILEMAP is %d by %d\n", mWidth, mHeight);
-  LongDump(mMapData, 32);
 }
 
 BTileMap::~BTileMap() {

--- a/src/BTileMap.h
+++ b/src/BTileMap.h
@@ -15,6 +15,8 @@ public:
 public:
   TUint16 mWidth, mHeight;
   TUint32 *mMapData;
+  TUint16 mObjectCount;
+  TUint16 *mObjectProgram;
   BBitmap *mTiles;
 };
 

--- a/tools/rcomp-src/CMakeLists.txt
+++ b/tools/rcomp-src/CMakeLists.txt
@@ -14,7 +14,7 @@ else ()
   #   message(STATUS "<<<<<<<<<<<<<<<<<<<<<<<<<< Falling back to default creative-engine path: ${CREATIVE_ENGINE_PATH}")
 endif ()
 
-
+# use all the CPU cores and threads
 ProcessorCount(N)
 if(NOT N EQUAL 0)
   set(N, N*2)         # use hyperthreads - processor count is 4 on an i7 that has 8 cores including hyperthreads
@@ -22,13 +22,10 @@ if(NOT N EQUAL 0)
   set(${PROJECT_NAME}_args ${${PROJECT_NAME}_args} PARALLEL_LEVEL ${N})
 endif()
 
-
 INCLUDE_DIRECTORIES(
   ${CREATIVE_ENGINE_PATH}/src
   ${CREATIVE_ENGINE_PATH}/tools/rcomp-src
 )
-
-
 
 add_executable(tools
   rcomp.cpp rcomp.h

--- a/tools/rcomp-src/TileMap.cpp
+++ b/tools/rcomp-src/TileMap.cpp
@@ -135,7 +135,7 @@ void TileMap::Write(ResourceFile &resourceFile) {
       TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
       TUint16 attr = tlc[tile];
       if (tile != 0 && attr != 0) {
-        printf("Found %d at row,col %d,%d\n", attr, row, col);
+//        printf("Found %d at row,col %d,%d\n", attr, row, col);
         // zero out tile to right and two tiles below so we don't process them
 //        objectLayer.SetCell(row, col, 0);
         objectLayer.SetCell(row, col + 1, 0);
@@ -159,7 +159,7 @@ void TileMap::Write(ResourceFile &resourceFile) {
       TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
       TUint16 attr = tlc[tile];
       if (tile != 0 && attr >= 16) {
-        printf("Found %d at row,col %d,%d\n", attr, row, col);
+//        printf("Found %d at row,col %d,%d\n", attr, row, col);
         *ip++ = attr;
         *ip++ = row;
         *ip++ = col;

--- a/tools/rcomp-src/TileMap.cpp
+++ b/tools/rcomp-src/TileMap.cpp
@@ -19,32 +19,30 @@ TileMap::TileMap(const char *path, const char *filename) {
     char *ptr = strrchr(work, '\\');
     if (ptr == ENull) {
       ptr = work;
-    }
-    else {
+    } else {
       ptr++;
     }
 
     sprintf(resourceFn, "%s/%s", resourceFile.path, ptr);
-    const char *extension = &ptr[strlen(ptr)-3];
+    const char *extension = &ptr[strlen(ptr) - 3];
     if (!strcasecmp(extension, "bmp")) {
       printf("-> %s\n", ptr);
       this->bmp = new BMPFile(resourceFn);
 //      printf("BITMAP %s\n", ptr);
-    }
-    else if (!strcasecmp(extension, "tlc")) {
+    } else if (!strcasecmp(extension, "tlc")) {
       printf("-> %s\n", ptr);
       this->mapAttributes = new RawFile(resourceFn);
-    }
-    else if (!strcasecmp(extension, "stm")) {
-      if (strcasestr(ptr, "TILE_LAYER") != ENull) {
+    } else if (!strcasecmp(extension, "stm")) {
+      if (strcasestr(ptr, "MAP_LAYER") != ENull) {
         printf("-> %s\n", ptr);
         this->mapData = new RawFile(resourceFn);
-      }
-      else {
+      } else if (strcasestr(ptr, "DATA_LAYER")) {
+        printf("OBJECT DATA\n");
+        this->objectData = new RawFile(resourceFn);
+      } else {
         printf("-> %s IGNORED (for now)\n", ptr);
       }
-    }
-    else {
+    } else {
       abort("unknown extension: %s\n", ptr);
     }
   }
@@ -59,6 +57,40 @@ struct MapData {
   char token[4];
   TUint16 width, height;
   TUint32 data[];
+};
+
+struct ObjectLayer {
+  ObjectLayer(TInt32 aWidth, TInt32 aHeight, TUint32 *aData, TUint32 size) {
+    width = aWidth;
+    height = aHeight;
+
+    data = new TUint32[size];
+    bzero(data, size);
+    memcpy(data, aData, size);
+  }
+
+  TUint16 GetCell(TInt row, TInt col) {
+    return data[row * width + col];
+  }
+
+  void SetCell(TInt row, TInt col, TUint16 val) {
+    data[row * width + col] = val;
+  }
+
+  void Dump(TInt row) {
+    printf("ROW %03d ", row);
+    HexDump(&data[row * width], width, width);
+  }
+
+  void Dump() {
+    for (TInt row = 0; row < height; row++) {
+      Dump(row);
+    }
+    printf("\n");
+  }
+
+  TInt32 width, height;
+  TUint32 *data;
 };
 
 void TileMap::Write(ResourceFile &resourceFile) {
@@ -78,20 +110,73 @@ void TileMap::Write(ResourceFile &resourceFile) {
   TUint16 bmp_id = resourceFile.StartResource(work);
   bmp->Write(resourceFile);
 
-  TUint16 *tlc = (TUint16 *)mapAttributes->data;
-  MapData *map = (MapData *)mapData->data;
+  auto *tlc = (TUint16 *) mapAttributes->data;
+  auto *map = (MapData *) mapData->data;
+  TInt32 width = map->width,
+    height = map->height;
+
   TUint32 *data = &map->data[0];
   printf("--> TILEMAP %s is %dx%d\n", filename, map->width, map->height);
   // We set the attributes bits in the map so the game can fiddle the individual tiles' bits during play.
-  for (TInt n=0; n<map->width * map->height; n++) {
-    data[n] |= TUint32(tlc[data[n]]) << 16;
+  for (TInt n = 0; n < map->width * map->height; n++) {
+    data[n] |= tlc[data[n]] << TUint16(16);
   }
+
+  ObjectLayer objectLayer(width, height, (TUint32 *) &objectData->data[4 * sizeof(TUint16)],
+                          objectData->size); // skip over STM and width,height
+
+  // count objects in DATA_LAYER
+  TUint16 objectCount = 0;
+#ifdef DEBUGME
+  objectLayer.Dump();
+#endif
+  for (TInt row = 0; row < height; row++) {
+    for (TInt col = 0; col < width; col++) {
+      TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
+      TUint16 attr = tlc[tile];
+      if (tile != 0 && attr != 0) {
+        printf("Found %d at row,col %d,%d\n", attr, row, col);
+        // zero out tile to right and two tiles below so we don't process them
+//        objectLayer.SetCell(row, col, 0);
+        objectLayer.SetCell(row, col + 1, 0);
+        objectLayer.SetCell(row + 1, col, 0);
+        objectLayer.SetCell(row + 1, col + 1, 0);
+        objectCount++;
+      }
+    }
+  }
+#ifdef DEBUGME
+  objectLayer.Dump();
+#endif
+
+  // generate OBJECT program
+  printf("Found %d objects\n", objectCount);
+  TUint16 objectProgram[3 * objectCount],
+    *ip = objectProgram;
+
+  for (TInt row = 0; row < height; row++) {
+    for (TInt col = 0; col < width; col++) {
+      TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
+      TUint16 attr = tlc[tile];
+      if (tile != 0 && attr >= 16) {
+        printf("Found %d at row,col %d,%d\n", attr, row, col);
+        *ip++ = attr;
+        *ip++ = row;
+        *ip++ = col;
+      }
+    }
+  }
+  HexDump(objectProgram, 3*objectCount, 3*objectCount);
 
   sprintf(work, "%s_MAP", filename);
   resourceFile.StartResource(work);
   resourceFile.Write(&bmp_id, sizeof(bmp_id));
+  resourceFile.Write(&objectCount, sizeof(objectCount));
+  resourceFile.Write(&objectProgram[0], sizeof(objectProgram));
 
   resourceFile.Write(&map->width, sizeof(map->width));
   resourceFile.Write(&map->height, sizeof(map->height));
-  resourceFile.Write(&data[0], map->width * map->height * sizeof(TUint32));
+  resourceFile.Write(&data[0], width * height * sizeof(TUint32));
+
+//  printf("objectProgram %d\n", sizeof(objectProgram));
 }

--- a/tools/rcomp-src/TileMap.h
+++ b/tools/rcomp-src/TileMap.h
@@ -16,8 +16,8 @@ public:
   const char *filename;
   BMPFile *bmp;
   RawFile *mapData;
+  RawFile *objectData;
   RawFile *mapAttributes;   // .tlc file contents = num_tiles_in_bmp words
 };
-
 
 #endif //RCOMP_TILEMAP_H

--- a/tools/rcomp-src/rcomp.h
+++ b/tools/rcomp-src/rcomp.h
@@ -30,8 +30,9 @@
 #endif
 
 extern void abort(const char *message, ...);
-extern void HexDump(TUint8 *ptr, int length);
-extern void HexDump(TUint32 *ptr, int length);
+extern void HexDump(TUint8 *ptr, int length, int width=8);
+extern void HexDump(TUint16 *ptr, int length, int width=8);
+extern void HexDump(TUint32 *ptr, int length, int width=8);
 extern char *skipbl(char *p);
 extern char *trim(char *p);
 extern void generate_define_name(char *base);

--- a/tools/rcomp-src/utils.cpp
+++ b/tools/rcomp-src/utils.cpp
@@ -11,17 +11,17 @@ void abort(const char *message, ...) {
   exit(EXIT_FAILURE);
 }
 
-void HexDump(TUint8 *ptr, int length) {
+void HexDump(TUint8 *ptr, int length, int width) {
   TUint32  addr = 0;
   TInt count = 0;
   while (length > 0) {
     printf("%08x ", addr);
-    for (int i = 0; i < 8 && --length > 0; i++) {
+    for (int i = 0; i < width && --length > 0; i++) {
       printf("%02x ", *ptr++);
       count++;
-      if (count > 7) {
+      if (count > width-1) {
         count = 0;
-        addr += 8;
+        addr += width;
         break;
       }
     }
@@ -29,17 +29,34 @@ void HexDump(TUint8 *ptr, int length) {
   }
 }
 
-void HexDump(TUint32 *ptr, int length) {
+void HexDump(TUint16 *ptr, int length, int width) {
   TUint32  addr = 0;
   TInt count = 0;
   while (length > 0) {
     printf("%08x ", addr);
-    for (int i = 0; i < 8 && --length > 0; i++) {
+    for (int i = 0; i < width && --length > 0; i++) {
+      printf("%04x ", *ptr++);
+      count++;
+      if (count > width-1) {
+        count = 0;
+        addr += width;
+        break;
+      }
+    }
+    printf("\n");
+  }
+}
+void HexDump(TUint32 *ptr, int length, int width) {
+  TUint32  addr = 0;
+  TInt count = 0;
+  while (length > 0) {
+    printf("%08x ", addr);
+    for (int i = 0; i < width && --length > 0; i++) {
       printf("%08x ", *ptr++);
       count++;
-      if (count > 7) {
+      if (count > width-1) {
         count = 0;
-        addr += 8;
+        addr += width;
         break;
       }
     }


### PR DESCRIPTION
Updated rcomp to compile compact Object placement in the playfield.

Each object is 3 TUint16: 1st is op code (e.g. position player, spawn spider, etc.).  So 6 bytes per "thing" to be spawned.

Associated CE classes fixed up to use the new rcomp output.
