### PR TITLE
rcomp layers

### DIFF
--- a/src/BBitmap.h
+++ b/src/BBitmap.h
@@ -63,8 +63,8 @@ class BFont;
  *
  */
 class BBitmap : public BBase {
-  friend BResourceManager;
-  friend Display;
+  friend class BResourceManager;
+  friend class Display;
 
 public:
   BBitmap(TUint aWidth, TUint aHeight, TUint aDepth,

--- a/src/BGameEngine.h
+++ b/src/BGameEngine.h
@@ -16,7 +16,7 @@
  * BGameEngine is the main class that implements the engine.
  */
 class BGameEngine : public BBase {
-  friend BPlayfield;
+  friend class BPlayfield;
 public:
   BGameEngine(BViewPort *aViewPort);
 

--- a/src/BMapPlayfield.cpp
+++ b/src/BMapPlayfield.cpp
@@ -1,9 +1,9 @@
 #include "CreativeEngine.h"
 #include "math.h"
 
-BMapPlayfield::BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId) : BPlayfield() {
+BMapPlayfield::BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId, TInt16 aSlot) : BPlayfield() {
   mViewPort      = aViewPort;
-  mTileMap       = gResourceManager.LoadTileMap(aResourceId);
+  mTileMap       = gResourceManager.LoadTileMap(aResourceId, aSlot);
   mMapWidth      = mTileMap->mWidth;
   mMapHeight     = mTileMap->mHeight;
   mMapData       = &mTileMap->mMapData[0];

--- a/src/BMapPlayfield.h
+++ b/src/BMapPlayfield.h
@@ -9,7 +9,7 @@ class BMapTileset;
 const TInt TILESIZE = 32;
 class BMapPlayfield : public BPlayfield {
 public:
-  BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId);
+  BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId, TInt16 aSlot);
 
   virtual ~BMapPlayfield();
 
@@ -32,7 +32,7 @@ public:
   TUint32 GetCell(TFloat aWorldX, TFloat aWorldY);
 
   TUint16 mObjectCount;
-  TUint16 *mObjectProgram;
+  BObjectProgram *mObjectProgram;
 
   BBitmap *GetTilesBitmap() { return mTileset; }
 

--- a/src/BResourceManager.cpp
+++ b/src/BResourceManager.cpp
@@ -107,12 +107,28 @@ BResourceManager::~BResourceManager() {
   ReleaseRawSlots();
 }
 
+TPalette *BResourceManager::LoadPalette(TInt16 aPaletteId) {
+  TUint8 *rom = &this->mROM[this->mResourceTable[aPaletteId]];
+  TPalette *p = new TPalette[256];
+  for (TInt c=0; c<256; c++) {
+    p[c].r = *rom++;
+    p[c].g = *rom++;
+    p[c].b = *rom++;
+  }
+  return p;
+}
+
+
+void BResourceManager::FreePalette(TPalette *aPalette) {
+  delete [] aPalette;
+}
+
 BBitmap *BResourceManager::LoadBitmap(TInt16 aResourceId) {
   return new BBitmap(&this->mROM[this->mResourceTable[aResourceId]]);
 }
 
-BTileMap *BResourceManager::LoadTileMap(TInt16 aResourceId) {
-  return new BTileMap(&this->mROM[this->mResourceTable[aResourceId]]);
+BTileMap *BResourceManager::LoadTileMap(TInt16 aResourceId, TInt16 aTilesetId) {
+  return new BTileMap(&this->mROM[this->mResourceTable[aResourceId]], aTilesetId);
 }
 
 // Load a bitmap from FLASH/ROM/RODATA into a slot

--- a/src/BResourceManager.h
+++ b/src/BResourceManager.h
@@ -11,9 +11,8 @@
  * COMPONENT_EMBED_FILES define in the component.mk for the game.
  */
 #include "BBase.h"
-
-class BBitmap;
-class BTileMap;
+#include "BTileMap.h"
+#include "BBitmap.h"
 
 // Each resource that is loaded requires allocated RAM, so we don't want to just load them all
 // from the FLASH/ROM/RODATA all at once.
@@ -95,7 +94,10 @@ public:
   ~BResourceManager();
 
 public:
-  BTileMap *LoadTileMap(TInt16 aResourceId);
+  TPalette *LoadPalette(TInt16 aResourceId);
+  void FreePalette(TPalette *aPalette);
+
+  BTileMap *LoadTileMap(TInt16 aResourceId, TInt16 aSlot);
   // Load a bitmap from Flash into a BBitmap
   BBitmap *LoadBitmap(TInt16 aResourceId);
 

--- a/src/BTileMap.cpp
+++ b/src/BTileMap.cpp
@@ -1,34 +1,37 @@
 #include "CreativeEngine.h"
 
-BTileMap::BTileMap(void *aRomData) {
-  TUint16 *rom = (TUint16 *)aRomData;
+BTileMap::BTileMap(void *aRomData, TInt16 aTilesetSlot) {
+  TUint16 *rom = (TUint16 *) aRomData;
   WordDump(rom, 32);
-  mTiles = gResourceManager.LoadBitmap(*rom++);
-  mObjectCount = *rom++;
-  mObjectProgram= &rom[0];
-  rom += mObjectCount * 3;
-  mWidth = *rom++;
-  mHeight = *rom++;
-  mMapData = new TUint32[mWidth * mHeight];
+  mTilesetSlot = aTilesetSlot;
+  if (!gResourceManager.LoadBitmap(*rom++, aTilesetSlot, IMAGE_32x32)) {
+    Panic("Can't loadBitmap(%d)\n", mTilesetSlot);
+  }
+  mTiles         = gResourceManager.GetBitmap(aTilesetSlot);
+  mObjectCount   = *rom++;
+  mObjectProgram = (BObjectProgram *) &rom[0];
+  rom            = (TUint16 *) &mObjectProgram[mObjectCount];
+  mWidth         = *rom++;
+  mHeight        = *rom++;
+  mMapData       = new TUint32[mWidth * mHeight];
   memcpy(mMapData, &rom[0], mWidth * mHeight * sizeof(TUint32));
   printf("TILEMAP is %d by %d\n", mWidth, mHeight);
 }
 
 BTileMap::~BTileMap() {
   delete mTiles;
-  delete [] this->mMapData;
+  delete[] this->mMapData;
 }
 
-
 TUint8 *BTileMap::TilePtr(TInt aRow, TInt aCol) {
-  const TInt index = aRow * mWidth + aCol,
-  tileNumber = mMapData[index] & TUint32(0xffff);
+  const TInt index      = aRow * mWidth + aCol,
+             tileNumber = mMapData[index] & TUint32(0xffff);
 
-  const TInt tw = mTiles->Width() / TILESIZE,
-    row = tileNumber / tw,
-    col = tileNumber % tw;
+  const TInt tw  = mTiles->Width() / TILESIZE,
+             row = tileNumber / tw,
+             col = tileNumber % tw;
 
-  const TInt offset = row * TILESIZE * mTiles->Width() + col*TILESIZE;
+  const TInt offset = row * TILESIZE * mTiles->Width() + col * TILESIZE;
   return &mTiles->mPixels[offset];
 }
 

--- a/src/BTileMap.h
+++ b/src/BTileMap.h
@@ -2,22 +2,31 @@
 #define BTILEMAP_H
 
 #include <BBase.h>
+#include <BBitmap.h>
 
 #define TILE_INDEX(n) (TUint16((n) & 0xffff))
 
+struct BObjectProgram {
+  TUint32 mCode;
+  TUint16 mRow, mCol;
+};
+
 class BTileMap : BBase {
 public:
-  BTileMap(void *aRomData);
+  BTileMap(void *aRomData, TInt16 aTilesetSlot);
+
   ~BTileMap();
+
 public:
   TUint8 *TilePtr(TInt aRow, TInt aCol);
 
 public:
-  TUint16 mWidth, mHeight;
-  TUint32 *mMapData;
-  TUint16 mObjectCount;
-  TUint16 *mObjectProgram;
-  BBitmap *mTiles;
+  TUint16        mWidth, mHeight;
+  TUint32        *mMapData;
+  TUint16        mObjectCount;
+  BObjectProgram *mObjectProgram;
+  TUint16        mTilesetSlot;
+  BBitmap        *mTiles;
 };
 
 #endif //BTILEMAP_H

--- a/src/BTypes.h
+++ b/src/BTypes.h
@@ -36,15 +36,15 @@ typedef float TFloat;
 #endif
 
 #ifndef HIBYTE
-#define HIBYTE(x) TUint8(((x) >> 8) & 0xff)
+#define HIBYTE(x) TUint8(((x) >> 8) & TUint8(0xff))
 #endif
 
 #ifndef LOWORD
-#define LOWORD(x) TUint16((x)&0xffff)
+#define LOWORD(x) TUint16((x)&TUint16(0xffff))
 #endif
 
 #ifndef HIWORD
-#define HIWORD(x) TUint16(((x) >> 16) & 0xffff)
+#define HIWORD(x) TUint16(((x) >> 16) & TUint16(0xffff))
 #endif
 
 #ifndef ABS

--- a/src/Types/TRGB.h
+++ b/src/Types/TRGB.h
@@ -90,4 +90,6 @@ public:
   }
 };
 
+typedef struct TRGB TPalette;
+
 #endif //GENUS_TRGB_H

--- a/tools/rcomp-src/TileMap.cpp
+++ b/tools/rcomp-src/TileMap.cpp
@@ -1,14 +1,38 @@
 #include "RawFile.h"
+#include "BTileMap.h"
 #include "TileMap.h"
+#include "stdio.h"
 
 #define DEBUGME
-#undef DEBUGME
+//#undef DEBUGME
+
+TInt ParseLayer(const char *str) {
+  char *pos = strcasestr(str, "Level_");
+  if (pos == ENull) {
+    printf("Level_ is required in filename (%s)\n", str);
+    exit(1);
+  }
+  pos = &pos[6];
+  TInt level = 0;
+  while (isdigit(*pos)) {
+    level *= 10;
+    level += *pos - '0';
+    pos++;
+  }
+  return level;
+}
 
 TileMap::TileMap(const char *path, const char *filename) {
-  this->filename = strdup(filename);
+  this->filename      = strdup(filename);
   this->mapAttributes = ENull;
-  this->mapData = ENull;
-  this->bmp = ENull;
+  this->bmp           = ENull;
+  for (TInt i = 0; i < MAX_LEVELS; i++) {
+    mLevels[i].used              = EFalse;
+    mLevels[i].map               = ENull;
+    mLevels[i].map_attributes    = ENull;
+    mLevels[i].object            = ENull;
+    mLevels[i].object_attributes = ENull;
+  }
 
   char work[2048], resourceFn[2048];
   sprintf(work, "%s/%s", path, filename);
@@ -40,11 +64,25 @@ TileMap::TileMap(const char *path, const char *filename) {
       this->mapAttributes = new RawFile(resourceFn);
     } else if (!strcasecmp(extension, "stm")) {
       if (strcasestr(ptr, "MAP_LAYER") != ENull) {
-        printf("-> %s\n", ptr);
-        this->mapData = new RawFile(resourceFn);
-      } else if (strcasestr(ptr, "DATA_LAYER")) {
-        printf("-> OBJECT DATA %s\n", ptr);
-        this->objectData = new RawFile(resourceFn);
+        printf("-> MAP LAYER %s\n", ptr);
+        TInt level = ParseLayer(ptr);
+        mLevels[level].used = ETrue;
+        mLevels[level].map  = new RawFile(resourceFn);
+      } else if (strcasestr(ptr, "MAP_ATTRIBUTE_LAYER") != ENull) {
+        printf("-> MAP ATTRIBUTES %s\n", ptr);
+        TInt level = ParseLayer(ptr);
+        mLevels[level].used           = ETrue;
+        mLevels[level].map_attributes = new RawFile(resourceFn);
+      } else if (strcasestr(ptr, "OBJECT_LAYER")) {
+        printf("-> OBJECT LAYER %s\n", ptr);
+        TInt level = ParseLayer(ptr);
+        mLevels[level].used   = ETrue;
+        mLevels[level].object = new RawFile(resourceFn);
+      } else if (strcasestr(ptr, "OBJECT_ATTRIBUTE_LAYER") != ENull) {
+        printf("-> OBJECT ATTRIBUTES %s\n", ptr);
+        TInt level = ParseLayer(ptr);
+        mLevels[level].used              = ETrue;
+        mLevels[level].object_attributes = new RawFile(resourceFn);
       } else {
         printf("-> %s IGNORED (for now)\n", ptr);
       }
@@ -59,15 +97,20 @@ TileMap::~TileMap() {
   delete this->filename;
 }
 
+void Dump() {
+
+}
+
 struct MapData {
-  char token[4];
+  char    token[4];
   TUint16 width, height;
   TUint32 data[];
 };
 
+#if 0
 struct ObjectLayer {
   ObjectLayer(TInt32 aWidth, TInt32 aHeight, TUint32 *aData, TUint32 size) {
-    width = aWidth;
+    width  = aWidth;
     height = aHeight;
 
     data = new TUint32[size];
@@ -95,16 +138,25 @@ struct ObjectLayer {
     printf("\n");
   }
 
-  TInt32 width, height;
+  TInt32  width, height;
   TUint32 *data;
 };
+#endif
+
+static void make_filename(char *dst, const char *src) {
+  while (*src) {
+    if (!strncasecmp(src, "FILELIST.TXT", 13)) {
+      src += 13;
+    } else {
+      *dst++ = *src++;
+    }
+  }
+  *dst = '\0';
+}
 
 void TileMap::Write(ResourceFile &resourceFile) {
   if (!mapAttributes) {
     abort("TileMap (%s) missing TLC\n:", filename);
-  }
-  if (!mapData) {
-    abort("TileMap (%s) missing STM\n:", filename);
   }
   if (!bmp) {
     abort("TileMap (%s) missing BMP\n:", filename);
@@ -112,77 +164,98 @@ void TileMap::Write(ResourceFile &resourceFile) {
 
   // write out the BMP
   char work[2048];
-  sprintf(work, "%s_BMP", filename);
+  make_filename(work, filename);
+  strcat(work, "BMP");
   TUint16 bmp_id = resourceFile.StartResource(work);
   bmp->Write(resourceFile);
 
-  TUint16 *tlc = (TUint16 *) mapAttributes->data;
-  MapData *map = (MapData *) mapData->data;
-  TInt32 width = map->width,
-    height = map->height;
+  TUint16   *tlc = (TUint16 *) mapAttributes->data;
+  for (TInt i    = 0; i < MAX_LEVELS; i++) {
+    LayerInfo *layer = &mLevels[i];
+    if (!layer->used) {
+      continue;
+    }
+    if (!layer->map || !layer->map_attributes || !layer->object || !layer->object_attributes) {
+      abort("Level %d is incomplete\n", i);
+    }
+    MapData *map               = (MapData *) layer->map->data;
+    MapData *map_attributes    = (MapData *) layer->map_attributes->data;
+    MapData *object            = (MapData *) layer->object->data;
+    MapData *object_attributes = (MapData *) layer->object_attributes->data;
+    TInt32  width              = map->width,
+            height             = map->height;
 
-  TUint32 *data = &map->data[0];
-  printf("--> TILEMAP %s is %dx%d\n", filename, map->width, map->height);
-  // We set the attributes bits in the map so the game can fiddle the individual tiles' bits during play.
-  for (TInt n = 0; n < map->width * map->height; n++) {
-    data[n] |= tlc[data[n]] << TUint16(16);
-  }
+    TUint32 *map_data               = &map->data[0],
+            *map_data_attributes    = &map_attributes->data[0];
+    TUint32 *object_data            = &object->data[0],
+            *object_data_attributes = &object_attributes->data[0];
 
-  ObjectLayer objectLayer(width, height, (TUint32 *) &objectData->data[4 * sizeof(TUint16)],
-                          objectData->size); // skip over STM and width,height
+    printf("--> TILEMAP %s Level %d is %dx%d\n", filename, i, map->width, map->height);
+    // We set the attributes bits in the map so the game can fiddle the individual tiles' bits during play.
+    for (TInt n = 0; n < map->width * map->height; n++) {
+      map_data[n] |= TUint32(tlc[map_data[n]] << TUint32(16));
+      map_data[n] |= TUint32(tlc[map_data_attributes[n]]) << TUint16(16);
+    }
+    HexDump(map_data, width, width);
 
-  // count objects in DATA_LAYER
-  TUint16 objectCount = 0;
-#ifdef DEBUGME
-  objectLayer.Dump();
-#endif
-  for (TInt row = 0; row < height; row++) {
-    for (TInt col = 0; col < width; col++) {
-      TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
-      TUint16 attr = tlc[tile];
-      if (tile != 0 && attr != 0) {
-        printf("Found %d at row,col %d,%d\n", attr, row, col);
-        // zero out tile to right and two tiles below so we don't process them
-//        objectLayer.SetCell(row, col, 0);
-        objectLayer.SetCell(row, col + 1, 0);
-        objectLayer.SetCell(row + 1, col, 0);
-        objectLayer.SetCell(row + 1, col + 1, 0);
-        objectCount++;
+    TUint16   objectCount = 0;
+    for (TInt row         = 0; row < height; row++) {
+      for (TInt col = 0; col < width; col++) {
+        const TInt    index = row * width + col;
+        const TUint32 tile  = LOWORD(object_data[index]);
+        const TUint32 attr1 = tlc[tile];
+        const TUint32 tile2 = LOWORD(object_data_attributes[index]);
+        const TUint32 attr2 = tlc[tile2];
+        const TUint32 attr  = attr2 << TUint32(16) | attr1;
+        if (tile && attr) {
+          objectCount++;
+        }
       }
     }
-  }
+
+    printf("Found %d objects\n", objectCount);
+
+    BObjectProgram objectProgram[objectCount],
+                   *ip    = &objectProgram[0];
+
+    if (objectCount) {
+      for (TInt row = 0; row < height; row++) {
+        for (TInt col = 0; col < width; col++) {
+          const TInt    index = row * width + col;
+          const TUint32 tile  = LOWORD(object_data[index]);
+          const TUint32 attr1 = tlc[tile];
+          const TUint32 tile2 = LOWORD(object_data_attributes[index]);
+          const TUint32 attr2 = tlc[tile2];
+          const TUint32 attr  = attr2 << TUint32(16) | attr1;
+
+          if (tile && attr) {
 #ifdef DEBUGME
-  objectLayer.Dump();
+            printf("found tile:%d tile2:%d at row,col:%d,%d attr1:%d attr2:%d attr:%08x\n", tile, tile2, row, col,
+                   attr1, attr2, attr);
 #endif
-
-  // generate OBJECT program
-  printf("Found %d objects\n", objectCount);
-  TUint16 objectProgram[3 * objectCount],
-    *ip = objectProgram;
-
-  for (TInt row = 0; row < height; row++) {
-    for (TInt col = 0; col < width; col++) {
-      TUint32 tile = objectLayer.GetCell(row, col) & TUint32(0xffff);
-      TUint16 attr = tlc[tile];
-      if (tile != 0 && attr >= 16) {
-//        printf("Found %d at row,col %d,%d\n", attr, row, col);
-        *ip++ = attr;
-        *ip++ = row;
-        *ip++ = col;
+            ip->mCode = attr;
+            ip->mRow  = row;
+            ip->mCol  = col;
+            ip++;
+          }
+        }
       }
     }
+
+//    ObjectLayer objectLayer(width, height, (TUint32 *) &object->data[4 * sizeof(TUint16)],
+//                            width * height); // skip over STM and width,height
+
+    make_filename(work, filename);
+    sprintf(&work[strlen(work)], "LEVEL%d_MAP", i);
+
+    resourceFile.StartResource(work);
+    resourceFile.Write(&bmp_id, sizeof(bmp_id));
+    resourceFile.Write(&objectCount, sizeof(objectCount));
+    resourceFile.Write(&objectProgram[0], sizeof(BObjectProgram) * objectCount);
+
+    resourceFile.Write(&map->width, sizeof(map->width));
+    resourceFile.Write(&map->height, sizeof(map->height));
+    resourceFile.Write(&map_data[0], width * height * sizeof(TUint32));
   }
-//  HexDump(objectProgram, 3*objectCount, 3*objectCount);
-
-  sprintf(work, "%s_MAP", filename);
-  resourceFile.StartResource(work);
-  resourceFile.Write(&bmp_id, sizeof(bmp_id));
-  resourceFile.Write(&objectCount, sizeof(objectCount));
-  resourceFile.Write(&objectProgram[0], sizeof(objectProgram));
-
-  resourceFile.Write(&map->width, sizeof(map->width));
-  resourceFile.Write(&map->height, sizeof(map->height));
-  resourceFile.Write(&data[0], width * height * sizeof(TUint32));
-
 //  printf("objectProgram %d\n", sizeof(objectProgram));
 }

--- a/tools/rcomp-src/TileMap.h
+++ b/tools/rcomp-src/TileMap.h
@@ -3,21 +3,34 @@
 
 #include "rcomp.h"
 
+const int MAX_LEVELS = 10;
+
 class RawFile;
+
 class BMPFile;
+
+struct LayerInfo {
+  TBool used;
+  RawFile *map;                   // map layer
+  RawFile *map_attributes;        // map attributes layer
+  RawFile *object;                // object layer
+  RawFile *object_attributes;     // object attributes layer
+};
 
 class TileMap {
 public:
   TileMap(const char *path, const char *filename);
+
   ~TileMap();
+
 public:
   void Write(ResourceFile &resourceFile);
+
 public:
   const char *filename;
-  BMPFile *bmp;
-  RawFile *mapData;
-  RawFile *objectData;
-  RawFile *mapAttributes;   // .tlc file contents = num_tiles_in_bmp words
+  BMPFile    *bmp;
+  LayerInfo  mLevels[MAX_LEVELS];
+  RawFile    *mapAttributes;   // .tlc file contents = num_tiles_in_bmp words
 };
 
 #endif //RCOMP_TILEMAP_H

--- a/tools/rcomp-src/rcomp.cpp
+++ b/tools/rcomp-src/rcomp.cpp
@@ -88,6 +88,21 @@ void process_tilemap(char *line) {
   map.Write(resourceFile);
 }
 
+void process_palette(char *line) {
+  char work[2048], base[2048];
+
+  strcpy(base, trim(&line[7]));
+  sprintf(work, "%s/%s", resourceFile.path, base);
+  sprintf(resourceFile.path, "%s/%s", dirname(work), basename(base));
+  RawFile *r = new RawFile(work);
+  if (!r->alive) {
+    abort("Can't open %s\n", work);
+  }
+  printf("%s: %d bytes\n", r->filename, r->size);
+  resourceFile.StartResource(base);
+  resourceFile.Write(r->data, 256*3);
+}
+
 void handle_file(char *fn) {
   char line[2048];
 
@@ -121,6 +136,9 @@ void handle_file(char *fn) {
     }
     else if (!strncasecmp(line, "TILEMAP", 7)) {
       process_tilemap(line);
+    }
+    else if (!strncasecmp(line, "PALETTE", 7)) {
+      process_palette(line);
     }
   }
 }

--- a/tools/rcomp-src/rcomp.h
+++ b/tools/rcomp-src/rcomp.h
@@ -1,7 +1,3 @@
-//
-// Created by mschwartz on 7/25/19.
-//
-
 #ifndef MODITE_RCOMP_H
 #define MODITE_RCOMP_H
 

--- a/tools/rcomp-src/utils.cpp
+++ b/tools/rcomp-src/utils.cpp
@@ -1,6 +1,3 @@
-//
-// Created by mschwartz on 7/25/19.
-//
 #include "rcomp.h"
 
 void abort(const char *message, ...) {


### PR DESCRIPTION
Modite-adventure: #106 

Uses 4 layers:
1) MAP_LAYER
2) MAP_ATTRIBUTES_LAYER
3) OBJECT_LAYER
4) OBJECT_ATTRIBUTES_LAYER

Map is width x height 32-bit words.  Low word is tile number.  High word is tlc of the tile OR tlc of the MAP_ATTRIBUTES_LAYER tile at the same location.

Generates BObjectProgram array of things to spawn.  Low word of the  32-bit word is the thing to spawn (e.g. enemy, player, stairs, ...) and High word is attributes (e.g for stairs, level to load).  Next two 16 bit words are row and column where to spawn the thing.

.pal files are supported.  BResourceManager::LoadPalette() returns an array of 256 TRGB values.  See TPalette.
