### PR TITLE
Cache ObjectPrograms

### DIFF
--- a/src/BMapPlayfield.h
+++ b/src/BMapPlayfield.h
@@ -10,7 +10,9 @@ const TInt TILESIZE = 32;
 
 class BMapPlayfield : public BPlayfield {
 public:
-  BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId, TInt16 aSlot);
+  // Create a playfield with tilemap.  If aCache is true, the map data is cached and reused if
+  // the same tilemap is instantiated again.
+  BMapPlayfield(BViewPort *aViewPort, TUint16 aResourceId, TInt16 aSlot, TBool aCache = EFalse);
 
   virtual ~BMapPlayfield();
 
@@ -46,7 +48,7 @@ public:
 protected:
   BViewPort *mViewPort;
   BTileMap  *mTileMap;
-  TInt      mSlot;
+  TInt      mResourceId, mSlot;
   BBitmap   *mTileset;
   TUint16   mMapWidth, mMapHeight;
   TUint32   *mMapData;

--- a/src/BTileMap.cpp
+++ b/src/BTileMap.cpp
@@ -1,19 +1,19 @@
 #include "CreativeEngine.h"
 
 BTileMap::BTileMap(void *aRomData, TInt16 aTilesetSlot) {
-  TUint16 *rom = (TUint16 *) aRomData;
-  WordDump(rom, 32);
+  TUint16 *rom = (TUint16 *)aRomData;
   mTilesetSlot = aTilesetSlot;
-  if (!gResourceManager.LoadBitmap(*rom++, aTilesetSlot, IMAGE_32x32)) {
+  mTilesetId= *rom++;
+  if (!gResourceManager.LoadBitmap(mTilesetId, mTilesetSlot, IMAGE_32x32)) {
     Panic("Can't loadBitmap(%d)\n", mTilesetSlot);
   }
-  mTiles         = gResourceManager.GetBitmap(aTilesetSlot);
-  mObjectCount   = *rom++;
-  mObjectProgram = (BObjectProgram *) &rom[0];
-  rom            = (TUint16 *) &mObjectProgram[mObjectCount];
-  mWidth         = *rom++;
-  mHeight        = *rom++;
-  mMapData       = new TUint32[mWidth * mHeight];
+  mTiles = gResourceManager.GetBitmap(aTilesetSlot);
+  mObjectCount = *rom++;
+  mObjectProgram = (BObjectProgram *)&rom[0];
+  rom = (TUint16 *)&mObjectProgram[mObjectCount];
+  mWidth = *rom++;
+  mHeight = *rom++;
+  mMapData = new TUint32[mWidth * mHeight];
   memcpy(mMapData, &rom[0], mWidth * mHeight * sizeof(TUint32));
   printf("TILEMAP is %d by %d\n", mWidth, mHeight);
 
@@ -38,10 +38,10 @@ BTileMap::~BTileMap() {
 }
 
 TUint32 *BTileMap::TilePtr(TInt aRow, TInt aCol) {
-  const TInt index      = aRow * mWidth + aCol,
+  const TInt index = aRow * mWidth + aCol,
              tileNumber = mMapData[index] & TUint32(0xffff);
 
-  const TInt tw  = mTiles->Width() / TILESIZE,
+  const TInt tw = mTiles->Width() / TILESIZE,
              row = tileNumber / tw,
              col = tileNumber % tw;
 
@@ -49,4 +49,3 @@ TUint32 *BTileMap::TilePtr(TInt aRow, TInt aCol) {
 
   return &mTiles->mPixels[offset];
 }
-

--- a/src/BTileMap.h
+++ b/src/BTileMap.h
@@ -25,7 +25,7 @@ public:
   TUint32        *mMapData;
   TUint16        mObjectCount;
   BObjectProgram *mObjectProgram;
-  TUint16        mTilesetSlot;
+  TUint16        mTilesetId, mTilesetSlot;
   BBitmap        *mTiles;
 };
 


### PR DESCRIPTION
This PR causes BTileMap to have the option to cache and reuse ObjectPrograms per level.

The effect of this is that the ObjectProgram (which is now in RAM) can be modified by the game logic.

For example, door is open, door logic sets op code in ObjectProgram for itself to "gone" state.

Next time the BTileMap is loaded, the ObjectProgram will have the gone status in it.
