### PR TITLE
Fix ma 302

### DIFF
--- a/src/BGameEngine.cpp
+++ b/src/BGameEngine.cpp
@@ -62,20 +62,22 @@ void BGameEngine::GameLoop() {
 
   if (mEnabled) {
     if (mPlayfield) {
-      // allow inheritor to set mWorldXX,mWorldYY as desired
-      PositionCamera();
       // animate the playfield
       mPlayfield->Animate();
-
-      if (mPlayfield != ENull) {
-        mPlayfield->Render();
-      }
     }
 
     if (!mPauseFlag) {
       mSpriteList.Move();
       mSpriteList.Animate();
       mProcessList.RunBefore();
+    }
+
+    if (mPlayfield) {
+      // allow inheritor to set mWorldXX,mWorldYY as desired
+      PositionCamera();
+      if (mPlayfield != ENull) {
+        mPlayfield->Render();
+      }
     }
     mSpriteList.Render(mViewPort);
 

--- a/src/BGameEngine.cpp
+++ b/src/BGameEngine.cpp
@@ -62,22 +62,20 @@ void BGameEngine::GameLoop() {
 
   if (mEnabled) {
     if (mPlayfield) {
+      // allow inheritor to set mWorldXX,mWorldYY as desired
+      PositionCamera();
       // animate the playfield
       mPlayfield->Animate();
+
+      if (mPlayfield != ENull) {
+        mPlayfield->Render();
+      }
     }
 
     if (!mPauseFlag) {
       mSpriteList.Move();
       mSpriteList.Animate();
       mProcessList.RunBefore();
-    }
-
-    if (mPlayfield) {
-      // allow inheritor to set mWorldXX,mWorldYY as desired
-      PositionCamera();
-      if (mPlayfield != ENull) {
-        mPlayfield->Render();
-      }
     }
     mSpriteList.Render(mViewPort);
 

--- a/src/BSprite.cpp
+++ b/src/BSprite.cpp
@@ -107,9 +107,9 @@ TBool BSprite::Render(BViewPort *aViewPort) {
     }
 
     return (mBitmap->TransparentColor() != -1)
-           ? gDisplay.renderBitmap->DrawBitmapTransparent(aViewPort, mBitmap, srcRect, round(screenX), round(screenY),
+           ? gDisplay.renderBitmap->DrawBitmapTransparent(aViewPort, mBitmap, srcRect, TInt(screenX), TInt(screenY),
                                                           (flags >> 6) & 0x0f)
-           : gDisplay.renderBitmap->DrawBitmap(aViewPort, mBitmap, srcRect, round(screenX), round(screenY),
+           : gDisplay.renderBitmap->DrawBitmap(aViewPort, mBitmap, srcRect, TInt(screenX), TInt(screenY),
                                                (flags >> 6) & 0x0f);
   }
 


### PR DESCRIPTION
See https://github.com/ModusCreateOrg/modite-adventure/pull/305

Changed BSprite coordinate rounding: BSprite::Render() uses round() on non-integer viewport coordinates, whereas BMapPlayfield::Render() uses a floor function. As a result, if the viewport origin is set to a coordinate with decimal part .0 to .5, sprites are offset one pixel relative to the background map. 

~~Changed order of main game loop: in Modite Adventure, the position of the viewport is based on the position of a possibly-moving sprite (the player), therefore properly aligning both the sprites and playfield with the viewport requires that both the sprite and playfield are rendered after sprites have finished moving and colliding.~~
