### PR TITLE
fix MAP_ATTRIBUTES_LAYER indexing

### DIFF
--- a/tools/rcomp-src/tmx/TMXMap.cpp
+++ b/tools/rcomp-src/tmx/TMXMap.cpp
@@ -176,7 +176,7 @@ TMXMap::TMXMap(const char *path, const char *filename) {
   // tile indexes for rendering in low word
   for (TInt n = 0; n < width * height; n++) {
     const TUint32 tile = map_layer->data[n] - 1;
-    const TUint32 atile = map_attributes_layer->data[n] - 1;
+    const TUint32 atile = map_attributes_layer->data[n];
     const TUint32 attr = attributes[atile];
     data[n] = (attr << 16) | tile;
   }


### PR DESCRIPTION
fix ATTRIBUTE values for tiles in MAP_ATTRIBUTES_LAYER getting read from tile in (index - 1)