### PR TITLE
Change game loop render order

### DIFF
--- a/src/BGameEngine.cpp
+++ b/src/BGameEngine.cpp
@@ -62,20 +62,20 @@ void BGameEngine::GameLoop() {
 
   if (mEnabled) {
     if (mPlayfield) {
-      // allow inheritor to set mWorldXX,mWorldYY as desired
-      PositionCamera();
       // animate the playfield
       mPlayfield->Animate();
-
-      if (mPlayfield != ENull) {
-        mPlayfield->Render();
-      }
     }
 
     if (!mPauseFlag) {
       mSpriteList.Move();
       mSpriteList.Animate();
       mProcessList.RunBefore();
+    }
+    // allow inheritor to set mWorldXX,mWorldYY as desired
+    PositionCamera();
+
+    if (mPlayfield != ENull) {
+      mPlayfield->Render();
     }
     mSpriteList.Render(mViewPort);
 


### PR DESCRIPTION
Changed game loop order so that PositionCamera(), playfield rendering, and sprite rendering occur together after RunBefore() tasks.

https://github.com/ModusCreateOrg/modite-adventure/pull/468