### PR TITLE
Found that we were cutting sprites by 1px on the bottom and right

### DIFF
--- a/src/BSprite.cpp
+++ b/src/BSprite.cpp
@@ -130,9 +130,9 @@ BSprite::DrawSprite(BViewPort *aViewPort, TInt16 aBitmapSlot, TInt aImageNumber,
 
   TRect imageRect;
   imageRect.x1 = (aImageNumber % pitch) * bw;
-  imageRect.x2 = imageRect.x1 + bw - 1;
+  imageRect.x2 = imageRect.x1 + bw;
   imageRect.y1 = (aImageNumber / pitch) * bh;
-  imageRect.y2 = imageRect.y1 + bh - 1;
+  imageRect.y2 = imageRect.y1 + bh;
 
   return b->TransparentColor()
          ? gDisplay.renderBitmap->DrawBitmapTransparent(aViewPort, b, imageRect, aX, aY, (aFlags >> 6) & 0x0f)


### PR DESCRIPTION
Tested with Genus (2020-refresh) and Modite-Adventure and this fixes an issue with Genus (see below).

![image](https://user-images.githubusercontent.com/180031/97616447-f51c8880-19f2-11eb-886d-f6e2bc61d7f4.png)
