### PR TITLE
672 Fix frame rate speed up

### DIFF
--- a/src/Controls/LDKControls/LDKControls.cpp
+++ b/src/Controls/LDKControls/LDKControls.cpp
@@ -34,7 +34,7 @@ TBool LDKControls::Poll()  {
 
   while (SDL_PollEvent(&e)) {
     if (pollNum > 100) {
-      printf("POLL %i\n", pollNum);
+//      printf("POLL %i\n", pollNum);
       fflush(stdout);
       pollNum = 0;
     }
@@ -49,7 +49,7 @@ TBool LDKControls::Poll()  {
 
     // Keyboard
     if (e.type == SDL_KEYDOWN) {
-      printf("KEYDOWN %i\n", e.key.keysym.scancode);
+//      printf("KEYDOWN %i\n", e.key.keysym.scancode);
       fflush(stdout);
 
       switch (e.key.keysym.scancode) {

--- a/src/Display/DesktopDisplay/DesktopDisplay.cpp
+++ b/src/Display/DesktopDisplay/DesktopDisplay.cpp
@@ -79,6 +79,7 @@ DesktopDisplay::DesktopDisplay() : Display() {
   int x, y;
   SDL_GetWindowPosition(screen, &x, &y);
   SDL_SetWindowPosition(screen, x + 1, y + 1);
+  mSLastTicks = SDL_GetTicks();
 }
 
 DesktopDisplay::~DesktopDisplay() {

--- a/src/Display/Display.h
+++ b/src/Display/Display.h
@@ -5,6 +5,7 @@
 #include "BBitmap.h"
 #include "DisplayDefines.h"
 #include <unistd.h>
+#include "SDL_timer.h"
 
 const TInt FRAMES_PER_SECOND = 60;
 
@@ -17,8 +18,9 @@ public:
     renderBitmap  = mBitmap1;
     displayBitmap = mBitmap2;
 
-    mSNow  = Milliseconds();
-    mSNext = mSNow + 1000 / FRAMERATE;
+    mSNow  = SDL_GetTicks();
+    mRate = 1000 / FRAMERATE;
+    mSLastTicks = SDL_GetTicks();
   }
 
   ~Display() {
@@ -55,11 +57,18 @@ public:
 
 
   void NextFrameDelay() {
-    if (mSNow < mSNext) {
-      usleep((mSNext - mSNow) * 1000);
+    Uint32 currentTicks = SDL_GetTicks();
+    mElapsed = currentTicks - mSLastTicks;
+
+    auto delay = (TUint32)ceil(mRate - mElapsed);
+//    fprintf(stdout, "DELAY %i | currentTicks %i | mElapsed  %i  | mLastTicks %i\n", delay, currentTicks, mElapsed, mSLastTicks);
+
+    if (mElapsed < mRate) {
+//      fprintf(stdout, "****SDL_DELAY(%i)*******\n", delay);
+      SDL_Delay(delay);
     }
-    mSNow = Milliseconds();
-    mSNext = mSNow + 1000 / FRAMERATE;
+
+    mSLastTicks = SDL_GetTicks();
   }
 
 
@@ -81,7 +90,7 @@ public:
   BBitmap *displayBitmap, *renderBitmap;
 
   const TUint32 FRAMERATE = FRAMES_PER_SECOND;
-  TUint32       mSNow, mSNext;
+  TUint32       mSNow, mSLastTicks, mElapsed, mRate;
 };
 
 extern Display &gDisplay;

--- a/src/Display/Display.h
+++ b/src/Display/Display.h
@@ -57,11 +57,9 @@ public:
   void NextFrameDelay() {
     if (mSNow < mSNext) {
       usleep((mSNext - mSNow) * 1000);
-
-      mSNow = Milliseconds();
     }
-
-    mSNext = (mSNext + 1000 / FRAMERATE);
+    mSNow = Milliseconds();
+    mSNext = mSNow + 1000 / FRAMERATE;
   }
 
 

--- a/src/Display/LDKDisplay/LDKDisplay.h
+++ b/src/Display/LDKDisplay/LDKDisplay.h
@@ -43,7 +43,9 @@ public:
 
   }
 
-  void Init() override {};
+  void Init() override {
+    mSLastTicks = SDL_GetTicks();
+  };
 
   void Update() override {
     SwapBuffers();


### PR DESCRIPTION
Fixes behavior where display would refresh at the maximum rate if the internal frame timer gets desynchronized from the system clock for any reason, like resources being hogged by another application, a single particularly resource-intensive frame like loading a level, or pausing the execution in a debugger. Timing is now relative to the previous frame only instead of calculated from the first frame.

close https://github.com/ModusCreateOrg/modite-adventure/issues/672